### PR TITLE
fix: Update TapForge pricing to regular rates in cost comparison

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -105,12 +105,12 @@
     },
     "tapforge": {
       "title": "TapForge",
-      "period": "¥700",
-      "monthlyCost": "Monthly fee: ¥0",
+      "period": "¥6,000~",
+      "monthlyCost": "Monthly fee: ¥500~ (for 6+ months use)",
       "orgTime": "Organization time: 5 minutes",
       "envImpact": "Environmental impact: Zero",
       "badges": {
-        "cost": "¥700",
+        "cost": "¥6K~",
         "time": "5min",
         "impact": "Zero"
       }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -105,12 +105,12 @@
     },
     "tapforge": {
       "title": "TapForge",
-      "period": "¥700",
-      "monthlyCost": "Cuota mensual: ¥0",
+      "period": "¥6,000~",
+      "monthlyCost": "Cuota mensual: ¥500~ (para uso de 6+ meses)",
       "orgTime": "Tiempo de organización: 5 minutos",
       "envImpact": "Impacto ambiental: Cero",
       "badges": {
-        "cost": "¥700",
+        "cost": "¥6K~",
         "time": "5min",
         "impact": "Cero"
       }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -105,12 +105,12 @@
     },
     "tapforge": {
       "title": "TapForge",
-      "period": "¥700",
-      "monthlyCost": "月額料金: ¥0",
+      "period": "¥6,000~",
+      "monthlyCost": "月額料金: ¥500~（半年以上ご利用の場合）",
       "orgTime": "整理時間: 5分",
       "envImpact": "環境負荷: ゼロ",
       "badges": {
-        "cost": "¥700",
+        "cost": "¥6K~",
         "time": "5分",
         "impact": "ゼロ"
       }

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -105,12 +105,12 @@
     },
     "tapforge": {
       "title": "TapForge",
-      "period": "¥700",
-      "monthlyCost": "월 사용료: ¥0",
+      "period": "¥6,000~",
+      "monthlyCost": "월 사용료: ¥500~ (6개월 이상 이용시)",
       "orgTime": "정리 시간: 5분",
       "envImpact": "환경 영향: 제로",
       "badges": {
-        "cost": "¥700",
+        "cost": "¥6K~",
         "time": "5분",
         "impact": "제로"
       }

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -105,12 +105,12 @@
     },
     "tapforge": {
       "title": "TapForge",
-      "period": "¥700",
-      "monthlyCost": "月费：¥0",
+      "period": "¥6,000~",
+      "monthlyCost": "月费: ¥500~（6个月以上使用的情况）",
       "orgTime": "整理时间：5分钟",
       "envImpact": "环境影响：零",
       "badges": {
-        "cost": "¥700",
+        "cost": "¥6K~",
         "time": "5分钟",
         "impact": "零"
       }


### PR DESCRIPTION
## Summary
Updated TapForge pricing in cost comparison section from beta testing rates to regular subscription rates across all 5 languages (ja, en, zh, ko, es).

## Changes
- **Period**: ¥700 → ¥6,000~
- **Monthly fee**: ¥0 → ¥500~ (for 6+ months use)
- **Badge display**: ¥700 → ¥6K~

## Affected Files
- `src/locales/ja/translation.json`
- `src/locales/en/translation.json`
- `src/locales/zh/translation.json`
- `src/locales/ko/translation.json`
- `src/locales/es/translation.json`

## Test Plan
- [x] Verify pricing display in Japanese version
- [x] Verify pricing display in English version
- [x] Verify pricing display in Chinese version
- [x] Verify pricing display in Korean version
- [x] Verify pricing display in Spanish version
- [ ] Visual regression testing on all language versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>